### PR TITLE
remove the jcenter bintray repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,10 +56,6 @@
       <url>https://repo.maven.apache.org/maven2</url>
     </repository>
     <repository>
-      <id>jcenter.bintray.com</id>
-      <url>https://jcenter.bintray.com</url>
-    </repository>
-    <repository>
       <id>artifact-registry</id>
       <url>${artifact-registry.url}</url>
       <releases>


### PR DESCRIPTION
this repository was shutdown in 2022
and no longer exists

the URL now points to the maven repository

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/statisticsnorway/dapla-dlp-pseudo-core/62)
<!-- Reviewable:end -->
