### PR TITLE
Add Maven Dependabot configuration

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -6,3 +6,9 @@ updates:
       default-days: 7
     schedule:
       interval: "weekly"
+  - package-ecosystem: "maven"
+    directory: "/"
+    cooldown:
+      default-days: 7
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## Summary
- enable weekly Dependabot updates for Maven dependencies from the repository root `pom.xml`
- keep the Maven update schedule and cooldown aligned with the existing GitHub Actions configuration

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/statisticsnorway/dapla-dlp-pseudo-core/63)
<!-- Reviewable:end -->
